### PR TITLE
Require port for packet matching

### DIFF
--- a/pcaplog/src/main.rs
+++ b/pcaplog/src/main.rs
@@ -9,6 +9,9 @@ use tracing_subscriber::EnvFilter;
 #[derive(Debug, Parser)]
 struct Args {
     file: PathBuf,
+
+    #[clap(short, long, default_value_t = 5678)]
+    port: u16,
 }
 
 #[derive(Serialize)]
@@ -22,7 +25,8 @@ fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     tracing::debug!(?args, "parsed command line arguments");
 
-    let messages = Messages(extract_messages(&args.file).context("extracting messages")?);
+    let messages =
+        Messages(extract_messages(&args.file, args.port).context("extracting messages")?);
     println!(
         "{}",
         serde_json::to_string_pretty(&messages).context("serializing messages")?

--- a/pcaplog/tests/captures.rs
+++ b/pcaplog/tests/captures.rs
@@ -14,25 +14,29 @@ pub struct Failure {
 
 #[rstest]
 #[trace]
-#[case("../captures/vscode/vscode-attach-connect.pcapng", 34)]
+#[case("../captures/vscode/vscode-attach-connect.pcapng", 5678, 34)]
 // #[trace]
-// #[case("../captures/vscode/dlv-debug-session.pcapng", 80)]
+// #[case("../captures/vscode/dlv-debug-session.pcapng", 5678, 80)]
 // #[trace]
-// #[case("../captures/vscode/full-session-multiple-breakpoints.pcapng", 108)]
+// #[case("../captures/vscode/full-session-multiple-breakpoints.pcapng", 5678, 108)]
 // #[trace]
-// #[case("../captures/vscode/full-session-testpy.pcapng", 93)]
+// #[case("../captures/vscode/full-session-testpy.pcapng", 5678, 93)]
 // #[trace]
-// #[case("../captures/vscode/session1.pcapng", 74)]
+// #[case("../captures/vscode/session1.pcapng", 5678, 74)]
 // #[trace]
-// #[case("../captures/vscode/session2.pcapng", 169)]
+// #[case("../captures/vscode/session2.pcapng", 5678, 169)]
 // #[trace]
-// #[case("../captures/vscode/stepover-go.pcapng", 16)]
+// #[case("../captures/vscode/stepover-go.pcapng", 5678, 16)]
 #[trace]
-#[case("../captures/vscode/vscode-attach-connect.pcapng", 34)]
-fn capture(#[case] path: &str, #[case] expected_count: usize) -> anyhow::Result<()> {
+#[case("../captures/vscode/vscode-attach-connect.pcapng", 5678, 34)]
+fn capture(
+    #[case] path: &str,
+    #[case] port: u16,
+    #[case] expected_count: usize,
+) -> anyhow::Result<()> {
     init_test_logger();
 
-    let messages = extract_messages(path).context("extracting messages")?;
+    let messages = extract_messages(path, port).context("extracting messages")?;
 
     assert_eq!(messages.len(), expected_count);
 


### PR DESCRIPTION
We should filter out the packets that match the specified port, as some
debugging sessions we have captured

* include additional packets which should be ignored
* may use a custom port
