### PR TITLE
Try to fix flaky CI tests

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -11,7 +11,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 env:
-  RUST_LOG: "gui=debug,transport=debug,end_to_end=trace"
+  RUST_LOG: "debugger=debug,gui=debug,transport=debug,end_to_end=trace"
 name: rolling
 jobs:
   # https://twitter.com/mycoliza/status/1571295690063753218

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 env:
-  RUST_LOG: "gui=debug,transport=debug,end_to_end=trace"
+  RUST_LOG: "debugger=debug,gui=debug,transport=debug,end_to_end=trace"
 name: test
 jobs:
   required:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,7 @@ name = "debugger"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "retry",
  "server",
  "spmc",
  "tracing",
@@ -432,6 +433,17 @@ dependencies = [
  "log",
  "rustversion",
  "windows",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -686,6 +698,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +719,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -772,6 +820,15 @@ name = "relative-path"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
+
+[[package]]
+name = "retry"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9166d72162de3575f950507683fac47e30f6f2c3836b71b7fbc61aa517c9c5f4"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "rstest"
@@ -1114,6 +1171,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -11,6 +11,7 @@ spmc.workspace = true
 tracing.workspace = true
 server = { path = "../server" }
 transport = { path = "../transport" }
+retry = "2.0.0"
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter"] }

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -1,10 +1,13 @@
 use std::{
-    net::TcpStream,
+    io,
+    net::{TcpStream, ToSocketAddrs},
     sync::{Arc, Mutex},
     thread,
+    time::Duration,
 };
 
 use anyhow::Context;
+use retry::{delay::Exponential, retry};
 use server::Implementation;
 use transport::{
     requests::{self, Disconnect},
@@ -32,6 +35,17 @@ impl From<state::AttachArguments> for InitialiseArguments {
     fn from(value: state::AttachArguments) -> Self {
         Self::Attach(value)
     }
+}
+
+fn retry_scale() -> impl Iterator<Item = Duration> {
+    Exponential::from_millis(200).take(5)
+}
+
+fn reliable_tcp_stream<A>(addr: A) -> Result<TcpStream, retry::Error<io::Error>>
+where
+    A: ToSocketAddrs + Clone,
+{
+    retry(retry_scale(), || TcpStream::connect(addr.clone()))
 }
 
 pub struct Debugger {
@@ -63,7 +77,7 @@ impl Debugger {
 
                 let s = server::for_implementation_on_port(implementation, port)
                     .context("creating background server process")?;
-                let stream = TcpStream::connect(format!("127.0.0.1:{port}"))
+                let stream = reliable_tcp_stream(format!("127.0.0.1:{port}"))
                     .context("connecting to server")?;
 
                 let (ttx, trx) = spmc::channel();
@@ -74,7 +88,7 @@ impl Debugger {
                 (internals, trx)
             }
             InitialiseArguments::Attach(_) => {
-                let stream = TcpStream::connect(format!("127.0.0.1:{port}"))
+                let stream = reliable_tcp_stream(format!("127.0.0.1:{port}"))
                     .context("connecting to server")?;
 
                 let (ttx, trx) = spmc::channel();

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -45,7 +45,19 @@ fn reliable_tcp_stream<A>(addr: A) -> Result<TcpStream, retry::Error<io::Error>>
 where
     A: ToSocketAddrs + Clone,
 {
-    retry(retry_scale(), || TcpStream::connect(addr.clone()))
+    retry(retry_scale(), || {
+        tracing::debug!("trying to make connection");
+        match TcpStream::connect(addr.clone()) {
+            Ok(stream) => {
+                tracing::debug!("connection made");
+                Ok(stream)
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "error making connection");
+                Err(e)
+            }
+        }
+    })
 }
 
 pub struct Debugger {


### PR DESCRIPTION
Fix CI connectivity issues and made the debugger crate more robust by adding retries to debugger connections. We retry 5 times with exponential backoff.
