### PR TITLE
Swap spmc for crossbeam-channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a9b73a36529d9c47029b9fb3a6f0ea3cc916a261195352ba19e770fc1748b2"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.17"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
+checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
 dependencies = [
  "cfg-if",
 ]
@@ -283,9 +293,9 @@ name = "debugger"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "crossbeam-channel",
  "retry",
  "server",
- "spmc",
  "tracing",
  "tracing-subscriber",
  "transport",
@@ -980,12 +990,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
-name = "spmc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a8428da277a8e3a15271d79943e80ccc2ef254e78813a166a08d65e4c3ece5"
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,12 +1138,12 @@ dependencies = [
  "anyhow",
  "bytes",
  "criterion",
+ "crossbeam-channel",
  "nom",
  "oneshot",
  "serde",
  "serde_json",
  "server",
- "spmc",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ debug = 1
 
 [workspace.dependencies]
 anyhow = "1.0.77"
-spmc = "0.3.0"
+crossbeam-channel = "0.5.10"
 tracing = "0.1.40"
 serde = { version = "1.0.193", features = ["derive"] }

--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
-spmc.workspace = true
+crossbeam-channel.workspace = true
 tracing.workspace = true
 server = { path = "../server" }
 transport = { path = "../transport" }

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -62,7 +62,7 @@ where
 
 pub struct Debugger {
     internals: Arc<Mutex<DebuggerInternals>>,
-    rx: spmc::Receiver<Event>,
+    rx: crossbeam_channel::Receiver<Event>,
 }
 
 impl Debugger {
@@ -74,7 +74,7 @@ impl Debugger {
         tracing::debug!("creating new client");
 
         // notify our subscribers
-        let (mut tx, rx) = spmc::channel();
+        let (tx, rx) = crossbeam_channel::unbounded();
         let _ = tx.send(Event::Uninitialised);
 
         let args: InitialiseArguments = initialise_arguments.into();
@@ -92,7 +92,7 @@ impl Debugger {
                 let stream = reliable_tcp_stream(format!("127.0.0.1:{port}"))
                     .context("connecting to server")?;
 
-                let (ttx, trx) = spmc::channel();
+                let (ttx, trx) = crossbeam_channel::unbounded();
                 let client =
                     transport::Client::new(stream, ttx).context("creating transport client")?;
 
@@ -103,7 +103,7 @@ impl Debugger {
                 let stream = reliable_tcp_stream(format!("127.0.0.1:{port}"))
                     .context("connecting to server")?;
 
-                let (ttx, trx) = spmc::channel();
+                let (ttx, trx) = crossbeam_channel::unbounded();
                 let client =
                     transport::Client::new(stream, ttx).context("creating transport client")?;
 
@@ -134,7 +134,7 @@ impl Debugger {
         Self::on_port(DEFAULT_DAP_PORT, initialise_arguments)
     }
 
-    pub fn events(&self) -> spmc::Receiver<Event> {
+    pub fn events(&self) -> crossbeam_channel::Receiver<Event> {
         self.rx.clone()
     }
 

--- a/debugger/src/internals.rs
+++ b/debugger/src/internals.rs
@@ -23,7 +23,7 @@ pub struct FileSource {
 
 pub(crate) struct DebuggerInternals {
     pub(crate) client: Client,
-    pub(crate) publisher: spmc::Sender<Event>,
+    pub(crate) publisher: crossbeam_channel::Sender<Event>,
 
     // debugger specific details
     pub(crate) current_thread_id: Option<ThreadId>,
@@ -38,7 +38,7 @@ pub(crate) struct DebuggerInternals {
 impl DebuggerInternals {
     pub(crate) fn new(
         client: Client,
-        publisher: spmc::Sender<Event>,
+        publisher: crossbeam_channel::Sender<Event>,
         server: Option<Box<dyn Server + Send>>,
     ) -> Self {
         Self::with_breakpoints(client, publisher, HashMap::new(), server)
@@ -80,7 +80,7 @@ impl DebuggerInternals {
 
     pub(crate) fn with_breakpoints(
         client: Client,
-        publisher: spmc::Sender<Event>,
+        publisher: crossbeam_channel::Sender<Event>,
         existing_breakpoints: impl Into<HashMap<BreakpointId, Breakpoint>>,
         server: Option<Box<dyn Server + Send>>,
     ) -> Self {

--- a/debugger/tests/debugger.rs
+++ b/debugger/tests/debugger.rs
@@ -171,7 +171,7 @@ fn init_test_logger() {
 #[tracing::instrument(skip(rx, pred))]
 fn wait_for_event<F>(
     message: &str,
-    rx: &spmc::Receiver<debugger::Event>,
+    rx: &crossbeam_channel::Receiver<debugger::Event>,
     pred: F,
 ) -> debugger::Event
 where

--- a/transport/Cargo.toml
+++ b/transport/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
-spmc.workspace = true
+crossbeam-channel.workspace = true
 tracing.workspace = true
 bytes = "1.4.0"
 oneshot = { version = "0.1.5", default-features = false, features = ["std"] }

--- a/transport/src/client.rs
+++ b/transport/src/client.rs
@@ -50,7 +50,10 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn new(stream: TcpStream, mut responses: spmc::Sender<events::Event>) -> Result<Self> {
+    pub fn new(
+        stream: TcpStream,
+        responses: crossbeam_channel::Sender<events::Event>,
+    ) -> Result<Self> {
         // internal state
         let sequence_number = Arc::new(AtomicI64::new(0));
 

--- a/transport/tests/end_to_end.rs
+++ b/transport/tests/end_to_end.rs
@@ -22,7 +22,7 @@ fn test_loop() -> Result<()> {
     let cwd = std::env::current_dir().unwrap();
     tracing::warn!(current_dir = ?cwd, "current_dir");
 
-    let (tx, rx) = spmc::channel();
+    let (tx, rx) = crossbeam_channel::unbounded();
     let port = get_random_tcp_port().context("getting free port")?;
     let _server = for_implementation_on_port(server::Implementation::Debugpy, port)
         .context("creating server process")?;
@@ -165,7 +165,11 @@ fn test_loop() -> Result<()> {
 }
 
 #[tracing::instrument(skip(rx, pred))]
-fn wait_for_event<F>(message: &str, rx: &spmc::Receiver<events::Event>, pred: F) -> events::Event
+fn wait_for_event<F>(
+    message: &str,
+    rx: &crossbeam_channel::Receiver<events::Event>,
+    pred: F,
+) -> events::Event
 where
     F: Fn(&events::Event) -> bool,
 {


### PR DESCRIPTION
crossbeam-channel is a much more common dependency that is likely more robust and well tested. We don't strictly need multiple producers for these channels, but the `select!` macro may come in handy in the future.
