### PR TITLE
Introduce dap-codec crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,8 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 [[package]]
 name = "dap"
 version = "0.4.1-alpha1"
-source = "git+https://github.com/simonrw/dap-rs?rev=5bdc158225c995219ca71a2887d871a156a117d9#5bdc158225c995219ca71a2887d871a156a117d9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c7fc89d334ab745ba679f94c7314c9b17ecdcd923c111df6206e9fd7729fa9"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,6 +1164,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
+name = "dap"
+version = "0.4.1-alpha1"
+source = "git+https://github.com/simonrw/dap-rs?rev=5bdc158225c995219ca71a2887d871a156a117d9#5bdc158225c995219ca71a2887d871a156a117d9"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "dap-codec"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "dap",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "dark-light"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4000,18 +4021,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4109,9 +4130,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,6 +1179,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "dap",
+ "futures",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -4139,9 +4140,23 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.5.5",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,7 @@ dependencies = [
  "bytes",
  "dap",
  "futures",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ members = [
     "pcaplog",
     "gui",
     "state",
-    "launch_configuration", "dap-codec",
+    "launch_configuration",
+    "dap-codec",
 ]
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
     "pcaplog",
     "gui",
     "state",
-    "launch_configuration",
+    "launch_configuration", "dap-codec",
 ]
 
 [profile.dev]

--- a/dap-codec/Cargo.toml
+++ b/dap-codec/Cargo.toml
@@ -11,3 +11,7 @@ tokio-util = { version = "0.7.10", features = ["codec"] }
 dap = { git = "https://github.com/simonrw/dap-rs", rev = "5bdc158225c995219ca71a2887d871a156a117d9" }
 bytes = "1.6.0"
 thiserror = "1.0.58"
+
+[dev-dependencies]
+futures = "0.3.30"
+tokio = { version = "1.37.0", features = ["full"] }

--- a/dap-codec/Cargo.toml
+++ b/dap-codec/Cargo.toml
@@ -6,11 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bytes = "1.6.0"
+dap = { git = "https://github.com/simonrw/dap-rs", rev = "5bdc158225c995219ca71a2887d871a156a117d9", features = ["client"] }
+serde_json = "1.0.115"
+thiserror = "1.0.58"
 tokio = { version = "1.37.0", features = ["net"] }
 tokio-util = { version = "0.7.10", features = ["codec"] }
-dap = { git = "https://github.com/simonrw/dap-rs", rev = "5bdc158225c995219ca71a2887d871a156a117d9" }
-bytes = "1.6.0"
-thiserror = "1.0.58"
 
 [dev-dependencies]
 futures = "0.3.30"

--- a/dap-codec/Cargo.toml
+++ b/dap-codec/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 bytes = "1.6.0"
-dap = { git = "https://github.com/simonrw/dap-rs", rev = "5bdc158225c995219ca71a2887d871a156a117d9", features = ["client"] }
+dap = { version = "0.4.1-alpha1", features = ["client"] }
 serde_json = "1.0.115"
 thiserror = "1.0.58"
 tokio = { version = "1.37.0", features = ["net"] }

--- a/dap-codec/Cargo.toml
+++ b/dap-codec/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "dap-codec"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tokio = { version = "1.37.0", features = ["net"] }
+tokio-util = { version = "0.7.10", features = ["codec"] }
+dap = { git = "https://github.com/simonrw/dap-rs", rev = "5bdc158225c995219ca71a2887d871a156a117d9" }
+bytes = "1.6.0"
+thiserror = "1.0.58"

--- a/dap-codec/src/lib.rs
+++ b/dap-codec/src/lib.rs
@@ -1,0 +1,14 @@
+use dap::base_message::Sendable;
+use tokio_util::codec::Decoder;
+
+struct DapDecoder {}
+
+impl Decoder for DapDecoder {
+    type Item = Sendable;
+
+    type Error = Box<dyn std::error::Error>;
+
+    fn decode(&mut self, src: &mut bytes::BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        todo!()
+    }
+}

--- a/dap-codec/src/lib.rs
+++ b/dap-codec/src/lib.rs
@@ -22,6 +22,17 @@ impl Decoder for DapDecoder {
     type Error = Box<dyn std::error::Error>;
 
     fn decode(&mut self, src: &mut bytes::BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        // skip to the start of the first header
+        // TODO: we assume Content-Length for now
+        let Some(start_pos) = src
+            .windows("Content-Length".len())
+            .position(|s| s == b"Content-Length")
+        else {
+            return Ok(None);
+        };
+
+        src.advance(start_pos);
+
         let Some(split_point) = src.windows(4).position(|s| s == b"\r\n\r\n") else {
             // TODO: is this always lack of input?
             return Ok(None);

--- a/dap-codec/src/lib.rs
+++ b/dap-codec/src/lib.rs
@@ -12,3 +12,20 @@ impl Decoder for DapDecoder {
         todo!()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use dap::events::Event;
+    use futures::prelude::*;
+    use tokio_util::codec::FramedRead;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn ping() {
+        let input = br#"Content-Length: 78\r\n\r\n{"seq":1,"type":"event","body":"Initialized"}"#;
+        let mut framed_read = FramedRead::new(&input[..], DapDecoder {});
+        let message = framed_read.next().await.unwrap().unwrap();
+        assert!(matches!(message, Sendable::Event(Event::Initialized)));
+    }
+}

--- a/shell.nix
+++ b/shell.nix
@@ -22,6 +22,7 @@ mkShell {
       cargo-flamegraph
       custom-python
       cargo-hack
+      cargo-expand
       act
       go
       delve


### PR DESCRIPTION
# Motivation

It would be good to create an easy to use abstraction for parsing messages. In this case, a `tokio_util::codec::Decoder` for messages.

# Changes

Create the initial 0.1.0 version of the new `dap-codec` crate.
